### PR TITLE
TM日本語版で音声モデルを作ると、ラベル選択メニューで表示されなくなるラベルがある

### DIFF
--- a/scratch-vm/src/extensions/scratch3_tm2scratch/index.js
+++ b/scratch-vm/src/extensions/scratch3_tm2scratch/index.js
@@ -633,11 +633,11 @@ class Scratch3TM2ScratchBlocks {
      * @return {Array} - Menu items with ''.
      */
     getSoundLabelsWithoutAnyMenu () {
-        let items = [''];
         if (this.soundMetadata) {
-            items = items.concat(this.soundMetadata.wordLabels);
+            return this.soundMetadata.wordLabels;
+        } else {
+            return [''];
         }
-        return items;
     }
 
     /**
@@ -647,7 +647,12 @@ class Scratch3TM2ScratchBlocks {
     getSoundLabelsWithoutBackgroundMenu () {
         let items = [Message.any[this.locale]];
         if (!this.soundMetadata) return items;
-        items = items.concat(this.soundMetadata.wordLabels.slice(1));
+        let arr = this.soundMetadata.wordLabels;
+        for (let i = 0; i < arr.length; i++) {
+            if (arr[i] !== '_background_noise_') {
+                items.push(arr[i]);
+            }
+        }
         return items;
     }
 
@@ -658,7 +663,12 @@ class Scratch3TM2ScratchBlocks {
     getSoundLabelsWithoutBackgroundWithAnyWithoutOfMenu () {
       let items = [Message.any_without_of[this.locale]];
       if (!this.soundMetadata) return items;
-      items = items.concat(this.soundMetadata.wordLabels.slice(1));
+      let arr = this.soundMetadata.wordLabels;
+      for (let i = 0; i < arr.length; i++) {
+          if (arr[i] !== '_background_noise_') {
+              items.push(arr[i]);
+          }
+      }
       return items;
     }
 


### PR DESCRIPTION
metada.jsonから音声モデルのラベルを取得し、_background_noise_を取り除くために一番最初のレベルを非表示にしていたが（_で始まるためほぼ常に最初に表示される）、日本語版では「バックグラウンド ノイズ」というラベル名となり、「バ」から始まるということで必ずしも一番最初には表示されない。
このため、一番最初に表示された通常のラベルが誤って削除されていたので、明示的に「_background_noise_」という名前のラベルを削除するように修正した。
なお、「バックグラウンド ノイズ」は音声ラベルとして表示されるので、こちらは削除せずメニューの内容に残しておいた。